### PR TITLE
Replace Travis with GitHub action CI

### DIFF
--- a/.github/workflows/run-validation.yml
+++ b/.github/workflows/run-validation.yml
@@ -1,0 +1,19 @@
+name: run-python-validation-script
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: checkout repo content
+        uses: actions/checkout@v2
+
+      - name: setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.6'
+
+     - name: execute python script
+       run: python tests/validate_mappings_file.py zoomage_report.CURATED.tsv

--- a/.github/workflows/run-validation.yml
+++ b/.github/workflows/run-validation.yml
@@ -6,7 +6,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-
       - name: checkout repo content
         uses: actions/checkout@v2
 
@@ -15,5 +14,5 @@ jobs:
         with:
           python-version: '3.6'
 
-     - name: execute python script
-       run: python tests/validate_mappings_file.py zoomage_report.CURATED.tsv
+      - name: execute python script
+        run: python tests/validate_mappings_file.py zoomage_report.CURATED.tsv

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: python
-python:
-  - "3.6"
-script:
-  - python tests/validate_mappings_file.py zoomage_report.CURATED.tsv


### PR DESCRIPTION
Travis is not offering free CI tests any more, so we need to switch to GitHub actions to run our validator. 

This PR also contains a remapping of the "chromium(6+)" annotation to the CHEBI term CHEBI_33007 (this was missed in previous PRs due to the CI tests not running). 