### PR TITLE
specify an available python version for PR checks

### DIFF
--- a/.github/workflows/run-validation.yml
+++ b/.github/workflows/run-validation.yml
@@ -12,7 +12,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.6.15'
 
       - name: execute python script
         run: python tests/validate_mappings_file.py zoomage_report.CURATED.tsv

--- a/.github/workflows/run-validation.yml
+++ b/.github/workflows/run-validation.yml
@@ -12,7 +12,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.6.15'
+          python-version: '3.11.1'
 
       - name: execute python script
         run: python tests/validate_mappings_file.py zoomage_report.CURATED.tsv


### PR DESCRIPTION
replace python version 3.6 with 3.6.15 to fix the error below:

Version 3.6 was not found in the local cache
Error: Version 3.6 with arch x64 not found
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json